### PR TITLE
Enable strict mode in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict"
+
 module.exports = babel => {
   const t = babel.types
 


### PR DESCRIPTION
So that Node 4.x won't complain `Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`